### PR TITLE
Use recommended noConflict method

### DIFF
--- a/app/admin.js
+++ b/app/admin.js
@@ -1,6 +1,6 @@
 /* global window, document */
 if (! window._babelPolyfill) {
-  require('@babel/polyfill');
+  require('@babel/polyfill/noConflict');
 }
 
 import React from 'react';


### PR DESCRIPTION
require('@babel/polyfill'); to require('@babel/polyfill/noConflict');

> wp-polyfill.min.js?ver=7.4.4:1 @babel/polyfill is loaded more than once on this page. This is probably not desirable/intended and may have consequences if different versions of the polyfills are applied sequentially. If you do need to load the polyfill more than once, use @babel/polyfill/noConflict instead to bypass the warning.